### PR TITLE
#4 - Permit notes to be resized

### DIFF
--- a/src/blocks/Note/Note.tsx
+++ b/src/blocks/Note/Note.tsx
@@ -1,10 +1,10 @@
-import { useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import clsx from "clsx";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { noteService } from "../../database/noteService";
-import { NoteItem, NoteModifyableFields } from "../../database/database";
-import { noteThemes } from "../../utilities/noteThemes";
+import { NoteItem } from "../../database/database";
 import { NoteMenu } from "./NoteMenu";
+import { noteThemes } from "../../utilities/noteThemes";
 import { NotePriority } from "./NotePriority";
 
 type NoteProps = {
@@ -16,70 +16,72 @@ export function Note(p: NoteProps) {
     const textareaId = useId();
     const nodeRef = useRef<HTMLElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const [deltaPos, setDeltaPos] = useState({
-        x: p.noteData.positionX,
-        y: p.noteData.positionY,
+
+    const [notePosition, setNotePosition] = useState({
+        posX: p.noteData.posX,
+        posY: p.noteData.posY,
+        posZ: p.noteData.posZ,
+        posW: p.noteData.posW,
+        posH: p.noteData.posH,
     });
 
-    function handleNoteModify(changes: NoteModifyableFields) {
-        noteService.modify(p.noteData.id, {
-            ...p.noteData,
-            ...changes,
-        });
+    useEffect(() => {
+        noteService.modify(p.noteData.id, notePosition);
+    }, [notePosition]);
+
+    function handleDragEvent(_: DraggableEvent, data: DraggableData) {
+        setNotePosition((prevState) => ({
+            ...prevState,
+            posX: prevState.posX + data.deltaX,
+            posY: prevState.posY + data.deltaY,
+        }));
+    }
+
+    function handleResizeEvent() {
+        const textareaSize = textareaRef.current?.getBoundingClientRect();
+        if (textareaSize?.width && textareaSize?.height) {
+            setNotePosition((prevState) => ({
+                ...prevState,
+                posW: textareaSize.width,
+                posH: textareaSize.height,
+            }));
+        }
     }
 
     async function handleBringForwards() {
         const highestId = await noteService.getTopZIndex();
-        if (highestId === p.noteData.positionZ) {
-            // Do nothing if already the highest
-            // onscreen element.
-            return;
+        if (highestId !== notePosition.posZ) {
+            setNotePosition((prevState) => ({
+                ...prevState,
+                posZ: highestId + 1,
+            }));
         }
-
-        handleNoteModify({
-            positionZ: highestId + 1,
-        });
     }
-
-    function handleDrag(_: DraggableEvent, data: DraggableData) {
-        const { x, y } = deltaPos;
-        setDeltaPos({
-            x: x + data.deltaX,
-            y: y + data.deltaY,
-        });
-    }
-
-    function handleDragStop() {
-        handleNoteModify({
-            positionX: deltaPos.x,
-            positionY: deltaPos.y,
-        });
-    }
-
-    const theme = noteThemes[p.noteData.theme] || noteThemes.yellow;
 
     return (
         <Draggable
             nodeRef={nodeRef}
             bounds="parent"
             handle=".handle"
-            position={deltaPos}
-            onDrag={handleDrag}
-            onStop={handleDragStop}
+            onDrag={handleDragEvent}
+            position={{
+                x: notePosition.posX,
+                y: notePosition.posY,
+            }}
         >
             <article
                 id={id}
                 ref={nodeRef}
                 className={clsx(
-                    "absolute w-[26rem] overflow-hidden rounded shadow-sm hover:shadow",
-                    theme.note,
+                    "absolute rounded shadow-sm hover:shadow",
+                    noteThemes[p.noteData.theme || "yellow"].note,
                     !p.noteData.content &&
                         !p.noteData.isPriority &&
                         "[&:not(:hover)]:animate-pulse",
                 )}
-                style={{ zIndex: `${p.noteData.positionZ}` }}
+                style={{ zIndex: notePosition.posZ }}
             >
-                <div className={clsx("flex items-stretch")}>
+                <div className={clsx("flex items-stretch rounded-t")}>
                     <div
                         onMouseDown={() => handleBringForwards()}
                         className="handle | grow cursor-grab px-2"
@@ -90,30 +92,30 @@ export function Note(p: NoteProps) {
                         noteData={p.noteData}
                     />
                 </div>
-                <section
-                    onMouseDown={() => handleBringForwards()}
-                    className={clsx("flex p-1")}
-                >
-                    <label className="hidden" htmlFor={textareaId}>
-                        Note Content
-                    </label>
-                    <textarea
-                        id={textareaId}
-                        rows={p.noteData.isMonospace ? 10 : 8}
-                        ref={textareaRef}
-                        onChange={() =>
-                            handleNoteModify({
-                                content: textareaRef.current?.value,
-                            })
-                        }
-                        placeholder="Click here to edit this note."
-                        defaultValue={p.noteData.content}
-                        className={clsx(
-                            "grow resize-none rounded-b bg-white/0 p-2",
-                            p.noteData.isMonospace && "font-mono text-sm",
-                        )}
-                    />
-                </section>
+                <label className="hidden" htmlFor={textareaId}>
+                    Note Content
+                </label>
+                <textarea
+                    id={textareaId}
+                    ref={textareaRef}
+                    onChange={() =>
+                        noteService.modify(p.noteData.id, {
+                            content: textareaRef.current?.value,
+                        })
+                    }
+                    onClick={() => handleBringForwards()}
+                    onMouseUp={() => handleResizeEvent()}
+                    placeholder="Click here to edit this note."
+                    defaultValue={p.noteData.content}
+                    style={{
+                        width: notePosition.posW,
+                        height: notePosition.posH,
+                    }}
+                    className={clsx(
+                        "min-h-[14.5em] min-w-[17em] resize rounded-b bg-white/0 p-2",
+                        p.noteData.isMonospace && "font-mono text-sm",
+                    )}
+                />
             </article>
         </Draggable>
     );

--- a/src/blocks/Note/NoteMenu.tsx
+++ b/src/blocks/Note/NoteMenu.tsx
@@ -83,7 +83,7 @@ export function NoteMenu(p: NoteMenuProps) {
             <Menu.Button
                 aria-label="Menu"
                 onClick={p.handleBringForwards}
-                className="px-4 py-2.5 hover:bg-gray-600/20 active:bg-gray-600/40 aria-expanded:bg-gray-600/20"
+                className="rounded-tr px-4 py-2.5 hover:bg-gray-600/20 active:bg-gray-600/40 aria-expanded:bg-gray-600/20"
             >
                 <EllipsisHorizontalIcon className="h-4" />
             </Menu.Button>
@@ -112,7 +112,7 @@ export function NoteMenu(p: NoteMenuProps) {
                                 />
                             ))}
                         </Menu.Item>
-                        <hr className="mb-1 border-gray-200"/>
+                        <hr className="mb-1 border-gray-200" />
                         {menuOptions.map((menuOption) => (
                             <Menu.Item key={menuOption.label}>
                                 <MenuButton

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1,22 +1,26 @@
 import Dexie, { IndexableType, Table } from "dexie";
 
 export type NoteModifyableFields = {
+    posX?: number;
+    posY?: number;
+    posZ?: number;
+    posH?: number;
+    posW?: number;
     theme?: string;
     content?: string;
     isPriority?: boolean;
     isMonospace?: boolean;
-    positionX?: number;
-    positionY?: number;
-    positionZ?: number;
 };
 
 export type NoteItem = {
     id: IndexableType;
+    posX: number;
+    posY: number;
+    posZ: number;
+    posH: number;
+    posW: number;
     theme: string;
     content: string;
-    positionX: number;
-    positionY: number;
-    positionZ: number;
     isPriority: boolean;
     isMonospace: boolean;
 };
@@ -27,9 +31,27 @@ export class MySubClassedDexie extends Dexie {
     constructor() {
         super("notedeck-db");
         this.version(1).stores({
-            // Primary key and indexed props
             notes: "++id, theme, content, positionX, positionY, positionZ, isPriority, isMonospace",
         });
+        this.version(2)
+            .stores({
+                notes: "++id, posX, posY, posZ, posH, posW, theme, content, isPriority, isMonospace",
+            })
+            .upgrade((transaction) => {
+                return transaction
+                    .table("notes")
+                    .toCollection()
+                    .modify((note) => {
+                        note.posX = note.positionX;
+                        note.posY = note.positionY;
+                        note.posZ = note.positionZ;
+                        note.posH = 200;
+                        note.posW = 400;
+                        delete note.positionX;
+                        delete note.positionY;
+                        delete note.positionZ;
+                    });
+            });
     }
 }
 

--- a/src/database/noteService.ts
+++ b/src/database/noteService.ts
@@ -18,15 +18,17 @@ async function _list() {
 }
 
 async function _getTopZIndex() {
-    const result = await database.table(TABLE_NAME).orderBy("positionZ").last();
-    return result?.positionZ || 0;
+    const result = await database.table(TABLE_NAME).orderBy("posZ").last();
+    return result?.posZ || 0;
 }
 
 type createArgs = {
     theme?: string;
     content?: string;
-    positionX?: number;
-    positionY?: number;
+    posX?: number;
+    posY?: number;
+    posH?: number;
+    posW?: number;
     isPriority?: boolean;
     isMonospace?: boolean;
 };
@@ -35,9 +37,11 @@ async function _create(args: createArgs) {
     const lastIndex = await _getTopZIndex();
     await database.table(TABLE_NAME).add({
         ...args,
-        positionX: args.positionX || 10,
-        positionY: args.positionY || 10,
-        positionZ: lastIndex + 1,
+        posX: args.posX || 10,
+        posY: args.posY || 10,
+        posH: args.posH || 200,
+        posW: args.posW || 400,
+        posZ: lastIndex + 1,
     });
 }
 


### PR DESCRIPTION
This PR introduces a first-iteration resize capability to notes.

- Notes have a minimum size to prevent rendering issues with the menu.
- I've attempted to use a debounce for this, but it's causing issues with the storing of positions, further research may be needed if this causes performance issues.
- Each`<textarea />` now has a dynamic height instead of being manually set by prop.