### PR TITLE
#18 - Duplicated notes should appear next to their ancestors

### DIFF
--- a/src/blocks/Note/NoteMenu.tsx
+++ b/src/blocks/Note/NoteMenu.tsx
@@ -31,7 +31,15 @@ export function NoteMenu(p: NoteMenuProps) {
     }
 
     function handleNoteDuplicate() {
+        // (Magic) Add X-20 and Y-100 pixels.
+        const maxX = p.noteData.posX + p.noteData.posW + 20;
+        const maxY = p.noteData.posY + p.noteData.posH + 120;
+        const tooWide = window.innerWidth < maxX;
+        const tooTall = window.innerHeight < maxY;
+
         serviceNote.create({
+            posX: p.noteData.posX + (tooWide ? -20 : 20),
+            posY: p.noteData.posY + (tooTall ? -20 : 20),
             posW: p.noteData.posW,
             posH: p.noteData.posH,
             theme: p.noteData.theme,

--- a/src/blocks/Note/NoteMenu.tsx
+++ b/src/blocks/Note/NoteMenu.tsx
@@ -31,7 +31,7 @@ export function NoteMenu(p: NoteMenuProps) {
     }
 
     function handleNoteDuplicate() {
-        // (Magic) Add X-20 and Y-100 pixels.
+        // (Magic) Add X-20 and Y-120 pixels.
         const maxX = p.noteData.posX + p.noteData.posW + 20;
         const maxY = p.noteData.posY + p.noteData.posH + 120;
         const tooWide = window.innerWidth < maxX;


### PR DESCRIPTION
This PR amends the logic for duplicating a note, to position it slightly offset to the ancestor note.

- For scenarios where the ancestor note is located along the bottom- or right-edges of the window, the duplicated note is positioned using negative values to avoid inducing scrollbars.
- "Magic numbers" are used to account for the `<Header />`  bar and screen padding.