### PR TITLE
#30 - Add support for manual theme switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,31 @@
         <meta name="description" content="A browser app for tracking your thoughts on virtual sticky notes." />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>NoteDeck</title>
+        <script>
+            function toggleTheme() {
+                if (
+                    localStorage.theme === "dark" ||
+                    (!("theme" in localStorage) &&
+                        window.matchMedia("(prefers-color-scheme: dark)")
+                            .matches)
+                ) {
+                    document.documentElement.classList.add("dark");
+                } else {
+                    document.documentElement.classList.remove("dark");
+                }
+            }
+
+            toggleTheme();
+
+            window
+                .matchMedia("(prefers-color-scheme: dark)")
+                .addEventListener("change", (e) => toggleTheme());
+        </script>
         <style>
-            body { background-color: rgb(250 250 250); }
             @media (prefers-color-scheme: dark) {
-                body { background-color: rgb(9 9 11); }
+                body {
+                    background-color: rgb(9 9 11);
+                }
             }
         </style>
     </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ export function App() {
 
     return (
         loaded && (
-            <div className="grid h-screen grid-rows-[auto,_1fr]">
+            <div className="grid h-screen grid-rows-[auto,_1fr] bg-primary-50 dark:bg-primary-950">
                 <Header />
                 <Main />
             </div>

--- a/src/blocks/Header/Header.tsx
+++ b/src/blocks/Header/Header.tsx
@@ -3,6 +3,7 @@ import { serviceNote } from "../../database/serviceNote";
 import { HeaderLogo } from "./HeaderLogo";
 import { HeaderMenu } from "./HeaderMenu";
 import { HeaderNewNote } from "./HeaderNewNote";
+import { HeaderThemeSwitch } from "./HeaderThemeSwitch";
 
 export function Header() {
     const notes = useLiveQuery(() => serviceNote.list());
@@ -11,6 +12,7 @@ export function Header() {
         <header className="flex items-center gap-2 border-b border-b-primary-200 bg-white px-4 py-1.5 dark:border-b-primary-800 dark:bg-primary-900">
             <HeaderLogo />
             {!!notes?.length && <HeaderNewNote />}
+            <HeaderThemeSwitch />
             <HeaderMenu hasNotes={!!notes?.length} />
         </header>
     );

--- a/src/blocks/Header/HeaderThemeSwitch.tsx
+++ b/src/blocks/Header/HeaderThemeSwitch.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { twJoin } from "tailwind-merge";
+import { Button } from "../../components/elements/Button";
+import {
+    ComputerDesktopIcon,
+    MoonIcon,
+    SunIcon,
+} from "@heroicons/react/16/solid";
+
+type themeList = "auto" | "dark" | "light";
+const THEME_AUTO = "auto";
+const THEME_DARK = "dark";
+const THEME_LIGHT = "light";
+
+export function HeaderThemeSwitch() {
+    const [theme, setTheme] = useState<themeList>(
+        localStorage.theme || THEME_AUTO,
+    );
+
+    function handleThemeChange(newTheme: themeList) {
+        setTheme(newTheme);
+        if (newTheme === THEME_AUTO) {
+            localStorage.removeItem("theme");
+        } else {
+            localStorage.theme = newTheme;
+        }
+        window.toggleTheme();
+    }
+
+    return (
+        <div className="box-content flex overflow-hidden items-center rounded">
+            <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleThemeChange(THEME_AUTO)}
+                className={twJoin(
+                    "rounded-none",
+                    theme !== THEME_AUTO
+                        ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
+                        : "bg-primary-100 dark:bg-primary-700",
+                )}
+            >
+                <ComputerDesktopIcon />
+            </Button>
+            <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleThemeChange(THEME_DARK)}
+                className={twJoin(
+                    "rounded-none",
+                    theme !== THEME_DARK
+                        ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
+                        : "bg-primary-100 dark:bg-primary-700",
+                )}
+            >
+                <MoonIcon />
+            </Button>
+            <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleThemeChange(THEME_LIGHT)}
+                className={twJoin(
+                    "rounded-none",
+                    theme !== THEME_LIGHT
+                        ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
+                        : "bg-primary-100 dark:bg-primary-700",
+                )}
+            >
+                <SunIcon />
+            </Button>
+        </div>
+    );
+}

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,6 @@
+// Required to ensure TS accepts a function
+// written in the `head` of `index.html`.
+
+declare interface Window {
+    toggleTheme: () => void;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,4 +28,5 @@ export default {
         },
     },
     plugins: [],
+    darkMode: "selector",
 };


### PR DESCRIPTION
Creates a new component `<HeaderThemeSwitch />` for manually selecting a theme.

Manual overrides to the theme are stored in Local Storage. The user's settings object in the IndexedDB database is not a suitable storage location as the data needs to be read outside of React.

The solution includes use of non-React JS in the `index.html` file which is responsible for handling OS-instigated changes to light/dark mode (via `addEventListener`). I also read and apply the current theme as early as possible in the DOM / loading sequence to reduce the time in which a light background is shown for dark mode users.