### PR TITLE
#34 - Ensure theme switcher is accessible via button tooltip

### DIFF
--- a/src/blocks/Header/HeaderThemeSwitch.tsx
+++ b/src/blocks/Header/HeaderThemeSwitch.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { twJoin } from "tailwind-merge";
 import { Button } from "../../components/elements/Button";
+import { Tooltip } from "../../components/elements/Tooltip";
 import {
     ComputerDesktopIcon,
     MoonIcon,
@@ -28,46 +29,61 @@ export function HeaderThemeSwitch() {
     }
 
     return (
-        <div className="box-content flex overflow-hidden items-center rounded">
-            <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => handleThemeChange(THEME_AUTO)}
-                className={twJoin(
-                    "rounded-none",
-                    theme !== THEME_AUTO
-                        ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
-                        : "bg-primary-100 dark:bg-primary-700",
-                )}
+        <div className="box-content flex items-center rounded">
+            <Tooltip
+                aria-hidden
+                label="System Theme"
             >
-                <ComputerDesktopIcon />
-            </Button>
-            <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => handleThemeChange(THEME_DARK)}
-                className={twJoin(
-                    "rounded-none",
-                    theme !== THEME_DARK
-                        ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
-                        : "bg-primary-100 dark:bg-primary-700",
-                )}
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleThemeChange(THEME_AUTO)}
+                    className={twJoin(
+                        "rounded-r-none",
+                        theme !== THEME_AUTO
+                            ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
+                            : "bg-primary-100 dark:bg-primary-700",
+                    )}
+                >
+                    <ComputerDesktopIcon aria-label="Use System Theme" />
+                </Button>
+            </Tooltip>
+            <Tooltip
+                aria-hidden
+                label="Dark Mode"
             >
-                <MoonIcon />
-            </Button>
-            <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => handleThemeChange(THEME_LIGHT)}
-                className={twJoin(
-                    "rounded-none",
-                    theme !== THEME_LIGHT
-                        ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
-                        : "bg-primary-100 dark:bg-primary-700",
-                )}
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleThemeChange(THEME_DARK)}
+                    className={twJoin(
+                        "rounded-none",
+                        theme !== THEME_DARK
+                            ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
+                            : "bg-primary-100 dark:bg-primary-700",
+                    )}
+                >
+                    <MoonIcon aria-label="Use Dark Mode" />
+                </Button>
+            </Tooltip>
+            <Tooltip
+                aria-hidden
+                label="Light Mode"
             >
-                <SunIcon />
-            </Button>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleThemeChange(THEME_LIGHT)}
+                    className={twJoin(
+                        "rounded-l-none",
+                        theme !== THEME_LIGHT
+                            ? "text-primary-400 dark:text-primary-500 bg-primary-50 dark:bg-primary-800"
+                            : "bg-primary-100 dark:bg-primary-700",
+                    )}
+                >
+                    <SunIcon aria-label="Use Light Mode" />
+                </Button>
+            </Tooltip>
         </div>
     );
 }

--- a/src/components/elements/Tooltip.tsx
+++ b/src/components/elements/Tooltip.tsx
@@ -1,0 +1,24 @@
+import { twMerge } from "tailwind-merge";
+
+interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {
+    label: string;
+}
+
+export function Tooltip(p: TooltipProps) {
+    const styles = {
+        container: "relative group flex flex-col items-center",
+        tooltipElement: twMerge(
+            "absolute top-10 min-w-28 px-2 py-1 z-50 text-center text-xs border rounded hidden group-hover:block",
+            "bg-white text-primary-600 border-primary-200 shadow-sm",
+            "dark:text-primary-200 dark:bg-primary-800 dark:border-primary-700",
+            p.className,
+        ),
+    };
+
+    return (
+        <div className={styles.container}>
+            {p.children}
+            <span className={styles.tooltipElement}>{p.label}</span>
+        </div>
+    );
+}

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -7,4 +7,4 @@ declare global {
     }
 }
 
-export {}
+export {};

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,6 +1,10 @@
 // Required to ensure TS accepts a function
 // written in the `head` of `index.html`.
 
-declare interface Window {
-    toggleTheme: () => void;
+declare global {
+    interface Window {
+        toggleTheme: () => void;
+    }
 }
+
+export {}


### PR DESCRIPTION
- Resolves a linting error caused by an incorrectly configured `window.toggleTheme()` typing.
- Creates a new `<Tooltip />` component and nests it around the `<ThemeSwitch />` buttons.

The `<Tooltip />` component is imperfect - I'm content with using it for now because it solves this bug, but further refactoring will be required in order to use it elsewhere.