### PR TITLE
#64 - Broken active state for buttons on Note menu

### DIFF
--- a/src/layout/Main/Note/NoteMenu.tsx
+++ b/src/layout/Main/Note/NoteMenu.tsx
@@ -143,26 +143,28 @@ export function NoteMenu(p: NoteMenuProps) {
                         <hr className="mb-1 border-primary-200 dark:border-primary-500" />
                         {menuItems.map((menuItem) => (
                             <MenuItem key={menuItem.label}>
-                                <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={menuItem.action}
-                                    className={
-                                        menuItem.isDestructive
-                                            ? "text-red-600 dark:text-red-500"
-                                            : ""
-                                    }
-                                >
-                                    <>
-                                        {menuItem.icon}
-                                        <span className="mr-auto">
-                                            {menuItem.label}
-                                        </span>
-                                        {menuItem.isActive && (
-                                            <CheckIcon className="fill-green-600 dark:fill-green-500" />
-                                        )}
-                                    </>
-                                </Button>
+                                <div>
+                                    <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        onClick={menuItem.action}
+                                        className={
+                                            menuItem.isDestructive
+                                                ? "w-full text-red-600 dark:text-red-500"
+                                                : "w-full"
+                                        }
+                                    >
+                                        <>
+                                            {menuItem.icon}
+                                            <span className="mr-auto">
+                                                {menuItem.label}
+                                            </span>
+                                            {menuItem.isActive && (
+                                                <CheckIcon className="fill-green-600 dark:fill-green-500" />
+                                            )}
+                                        </>
+                                    </Button>
+                                </div>
                             </MenuItem>
                         ))}
                     </div>

--- a/src/layout/Main/Note/NoteMenuTheme.tsx
+++ b/src/layout/Main/Note/NoteMenuTheme.tsx
@@ -14,7 +14,7 @@ export function NoteMenuTheme(p: NoteMenuThemeProps) {
         : `This note is currently using the  ${p.themeId} theme.`;
 
     const styles = twMerge(
-        "rounded-full border p-3",
+        "rounded-full border border-4 p-2 active:ring-1 active:ring-primary-600 dark:active:ring-primary-500",
         theme.selectionButton,
         p.themeIsActive && "ring-1 ring-primary-800 dark:ring-primary-100",
     );


### PR DESCRIPTION
Turns out that active state was "blocked" by [an existing bug in Headless UI](https://github.com/tailwindlabs/headlessui/issues/2609). The solution was to wrap each button inside `<MenuItem />` component with a `<div />`.