### PR TITLE
fix: Correct broken GitHub link in mobile view.

### DIFF
--- a/src/providers/check-viewport.tsx
+++ b/src/providers/check-viewport.tsx
@@ -1,4 +1,4 @@
-import { Link } from "lucide-react";
+import { Link } from "@/components/elements/link";
 import React from "react";
 import { isMobile } from "react-device-detect";
 
@@ -11,19 +11,21 @@ export const CheckViewportProvider = ({
     return (
       <div className="bg-base-50 dark:bg-base-950 grid h-dvh grid-rows-[auto_1fr]">
         <header className="p-10">
-          <span className="text-base-950 dark:text-base-100 text-sm font-semibold tracking-tight">
+          <h1 className="text-base-950 dark:text-base-100 text-lg font-semibold tracking-tight">
             NoteDeck
-          </span>
+          </h1>
         </header>
         <main className="m-auto max-w-sm p-10 pb-20">
-          <h2>Sorry, mobile devices are not supported :/</h2>
-          <p>To explore NoteDeck, open this page on your desktop or laptop.</p>
-          <p>
+          <h2 className="mb-6 text-xl">
+            Sorry, mobile devices are not supported <span aria-hidden>:/</span>
+          </h2>
+          <p className="mb-8">
+            To explore NoteDeck, open this page on your desktop or laptop.{" "}
             <Link
               href="https://github.com/abiddiscombe/notedeck"
               target="_blank"
             >
-              Learn more about NoteDeck.
+              Learn more.
             </Link>
           </p>
         </main>


### PR DESCRIPTION
Fixes an issue where `check-viewport.tsx` imported the `Link` SVG from Lucide Icons instead of the internal `Link` component.