### PR TITLE
chore: Update GH Actions to use latest templates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,12 @@ jobs:
     environment: prod1
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: "Setup Node"
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Login to AB Internal Registry
         uses: docker/login-action@v4
@@ -69,7 +69,7 @@ jobs:
             ${{ vars.AB_INT_REGISTRY_HOST }}/notes:${{ steps.release.outputs.semver }}
 
         # == FOR NOTEDECK.DEV DEPLOYMENT ONLY ==
-      - name: "[ 7 ] Deploy to Azure Static Web Apps"
+      - name: "Deploy to Azure Static Web Apps"
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_STONE_029252903 }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -9,28 +9,28 @@ jobs:
   job_validation:
     runs-on: ubuntu-latest
     steps:
-      - name: "[ 1 ] Checkout"
-        uses: actions/checkout@v3
+      - name: "Checkout"
+        uses: actions/checkout@v6
 
-      - name: "[ 2 ] Setup Node"
-        uses: actions/setup-node@v1
+      - name: "Setup Node"
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
-      - name: "[ 3 ] Install PNPM"
+      - name: "Install PNPM"
         uses: pnpm/action-setup@v6
         with:
           version: latest
     
-      - name: "[ 4 ] Install Deps"
+      - name: "Install Deps"
         run: pnpm install
 
-      - name: "[ 5A ] Validate: ESLint"
+      - name: "Validate: ESLint"
         run: pnpm lint:ci
 
-      - name: "[ 5B ] Validate: TS Types"
+      - name: "Validate: TS Types"
         run: pnpm types:ci
       
-      - name: "[ 5C ] Validate: Prettier"
+      - name: "Validate: Prettier"
         run: pnpm format:ci
         


### PR DESCRIPTION
This change updates the GH Actions used in workflows to heed the Node v20 deprecation notice.